### PR TITLE
Assume rooms with no state aren't new when processing invites

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ dev =
   # for type checking
   mypy == 0.910
   # for linting
-  black == 21.9b0
+  black == 22.3.0
   flake8 == 4.0.1
   isort == 5.9.3
 

--- a/synapse_domain_rule_checker/__init__.py
+++ b/synapse_domain_rule_checker/__init__.py
@@ -144,7 +144,8 @@ class DomainRuleChecker(object):
         """
 
         if self._config.can_only_invite_during_room_creation:
-            # If we can only invite during room creation, check whether our
+            # If we can only invite during room creation, check whether this invite is
+            # for a room that fits our definition of new.
             if not await self._is_new_room(room_id):
                 return False
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -36,6 +36,7 @@ class MockModuleApi:
 
     _new_room: bool
     _published: bool
+    _unknown_room: bool
 
     def register_spam_checker_callbacks(self, *args: Any, **kwargs: Any) -> None:
         """Don't fail when the module tries to register its callbacks."""
@@ -52,8 +53,12 @@ class MockModuleApi:
     async def get_room_state(self, *args: Any, **kwargs: Any) -> StateMap[MockEvent]:
         """Mocks the ModuleApi's get_room_state method, by returning mock events. The
         number of events depends on whether we're testing for a new room or not (if the
-        room is not new it will have an extra user joined to it).
+        room is not new it will have an extra user joined to it), or if the room is know
+        or not.
         """
+        if self._unknown_room:
+            return {}
+
         state = {
             (EventTypes.Create, ""): MockEvent("room_creator"),
             (EventTypes.Member, "room_creator"): MockEvent("room_creator", "join"),
@@ -67,11 +72,11 @@ class MockModuleApi:
 
 
 def create_module(
-    config_dict: Dict[str, Any], new_room: bool, published: bool
+    config_dict: Dict[str, Any], new_room: bool, published: bool, unknown_room: bool
 ) -> DomainRuleChecker:
     # Create a mock based on the ModuleApi spec, but override some mocked functions
     # because some capabilities are needed for running the tests.
-    module_api = MockModuleApi(new_room, published)
+    module_api = MockModuleApi(new_room, published, unknown_room)
 
     # If necessary, give parse_config some configuration to parse.
     config = DomainRuleChecker.parse_config(config_dict)

--- a/tests/test_domain_rule_checker.py
+++ b/tests/test_domain_rule_checker.py
@@ -288,7 +288,7 @@ class DomainRuleCheckerTestCase(aiounittest.AsyncTestCase):
         }
         self.assertRaises(ConfigError, DomainRuleChecker.parse_config, config)
 
-    def test_invite_unknown_room(self) -> None:
+    async def test_invite_unknown_room(self) -> None:
         """Tests that processing an invite for a room we don't have state for makes the
         module think the room is not new, and therefore rejects the invite if the server
         is only configured to accept invites during room creation.

--- a/tests/test_domain_rule_checker.py
+++ b/tests/test_domain_rule_checker.py
@@ -297,9 +297,7 @@ class DomainRuleCheckerTestCase(aiounittest.AsyncTestCase):
         received the invite over federation and we're not yet in the room.
         """
 
-        config = {
-            "can_only_invite_during_room_creation": True
-        }
+        config = {"can_only_invite_during_room_creation": True}
 
         self.assertFalse(
             await self._test_user_may_invite(

--- a/tests/test_domain_rule_checker.py
+++ b/tests/test_domain_rule_checker.py
@@ -297,7 +297,10 @@ class DomainRuleCheckerTestCase(aiounittest.AsyncTestCase):
         received the invite over federation and we're not yet in the room.
         """
 
-        config = {"can_only_invite_during_room_creation": True}
+        config = {
+            "can_invite_if_not_in_domain_mapping": True,
+            "can_only_invite_during_room_creation": True,
+        }
 
         self.assertFalse(
             await self._test_user_may_invite(


### PR DESCRIPTION
Currently we assume we always have state for a room we're processing an invite for. This is not always true, e.g. if we're receiving an invite over federation and we're not already in the room.

This reproduces the behaviour of the module before it got split out of synapse-dinsic, except at that time we considered _all_ invites received over federation as being in a new room.

I've also sneaked in a quick optimisation to avoid hitting the DB to check if a room is new when we don't actually care about it.