### PR TITLE
can_only_invite_during_room_creation: only apply to local invites

### DIFF
--- a/synapse_domain_rule_checker/__init__.py
+++ b/synapse_domain_rule_checker/__init__.py
@@ -147,8 +147,8 @@ class DomainRuleChecker(object):
 
         if (
             self._config.can_only_invite_during_room_creation
-            # only apply to room created locally,
-            # invites coming through fed should still go further
+            # Only check if the room is new for rooms created locally, because we
+            # can't reliably figure out whether a remote invite is for a new room.
             and inviter_domain == self._api.server_name
         ):
             # If we can only invite during room creation, check whether this invite is

--- a/synapse_domain_rule_checker/__init__.py
+++ b/synapse_domain_rule_checker/__init__.py
@@ -143,7 +143,14 @@ class DomainRuleChecker(object):
             Whether the invite can be allowed to go through.
         """
 
-        if self._config.can_only_invite_during_room_creation:
+        inviter_domain = self._get_domain_from_id(inviter_userid)
+
+        if (
+            self._config.can_only_invite_during_room_creation
+            # only apply to room created locally,
+            # invites coming through fed should still go further
+            and inviter_domain == self._api.server_name
+        ):
             # If we can only invite during room creation, check whether this invite is
             # for a room that fits our definition of new.
             if not await self._is_new_room(room_id):
@@ -155,7 +162,6 @@ class DomainRuleChecker(object):
         if invitee_userid is None:
             return self._config.can_invite_by_third_party_id
 
-        inviter_domain = self._get_domain_from_id(inviter_userid)
         invitee_domain = self._get_domain_from_id(invitee_userid)
 
         published_room = (

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -38,6 +38,8 @@ class MockModuleApi:
     _published: bool
     _unknown_room: bool
 
+    server_name: str = "source_one"
+
     def register_spam_checker_callbacks(self, *args: Any, **kwargs: Any) -> None:
         """Don't fail when the module tries to register its callbacks."""
         pass

--- a/tests/test_domain_rule_checker.py
+++ b/tests/test_domain_rule_checker.py
@@ -312,3 +312,27 @@ class DomainRuleCheckerTestCase(aiounittest.AsyncTestCase):
                 unknown_room=True,
             )
         )
+
+    async def test_remote_invite(self) -> None:
+        """Tests that we can still receive invite from remote servers even if
+        the server is configured to only accept invites during room creation.
+
+        It is possible to receive an invite for a room we don't have state for if we've
+        received the invite over federation and we're not yet in the room.
+        """
+
+        config = {
+            "can_invite_if_not_in_domain_mapping": True,
+            "can_only_invite_during_room_creation": True,
+        }
+
+        self.assertTrue(
+            await self._test_user_may_invite(
+                config,
+                "@test:source_two",
+                "@test2:source_one",
+                False,
+                False,
+                unknown_room=True,
+            )
+        )

--- a/tests/test_domain_rule_checker.py
+++ b/tests/test_domain_rule_checker.py
@@ -316,9 +316,6 @@ class DomainRuleCheckerTestCase(aiounittest.AsyncTestCase):
     async def test_remote_invite(self) -> None:
         """Tests that we can still receive invite from remote servers even if
         the server is configured to only accept invites during room creation.
-
-        It is possible to receive an invite for a room we don't have state for if we've
-        received the invite over federation and we're not yet in the room.
         """
 
         config = {


### PR DESCRIPTION
`can_only_invite_during_room_creation` should only check local invites against room creation, or remote invites coming through the federation are also rejected.

Fix #2 .