### PR TITLE
regex matching for domain names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,16 +30,11 @@ jobs:
   unit-tests:
     name: Unit tests
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # Run the unit tests both against our oldest supported Python version
-        # and the newest stable.
-        python_version: [ "3.7", "3.x" ]
     steps: 
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: "3.x"
       - run: python -m pip install tox
       - run: tox -e py
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Then alter your homeserver configuration, adding to your `modules` configuration
 modules:
   - module: synapse_domain_rule_checker.DomainRuleChecker
     config:
+      # Use regex for all domain comparisons
+      use_regex: false
+
       # A mapping describing which servers a server can invite into a room.
       # Default is any server can invite any other server.
       domain_mapping:

--- a/tests/test_domain_rule_checker.py
+++ b/tests/test_domain_rule_checker.py
@@ -111,12 +111,136 @@ class DomainRuleCheckerTestCase(aiounittest.AsyncTestCase):
             ),
         )
 
+    async def test_allowed_regex(self) -> None:
+        config = {
+            "can_invite_if_not_in_domain_mapping": False,
+            "use_regex": True,
+            "domain_mapping": {
+                "source_one": ["target_(one|two)"],
+                "source_two": [".*_two"],
+            },
+            "domains_prevented_from_being_invited_to_published_rooms": ["target_two"],
+        }
+
+        # Check that a user can invite a remote server if the domain mapping allows it.
+        self.assertTrue(
+            await self._test_user_may_invite(
+                config,
+                "test:source_one",
+                "test:target_one",
+                False,
+                False,
+            ),
+        )
+
+        # Check that a user can invite a remote server if the domain mapping allows it.
+        self.assertTrue(
+            await self._test_user_may_invite(
+                config,
+                "test:source_one",
+                "test:target_two",
+                False,
+                False,
+            ),
+        )
+
+        # Check that a user can invite a remote server if the domain mapping allows it.
+        self.assertTrue(
+            await self._test_user_may_invite(
+                config,
+                "test:source_two",
+                "test:target_two",
+                False,
+                False,
+            ),
+        )
+
+        # User can invite internal user to a published room
+        self.assertTrue(
+            await self._test_user_may_invite(
+                config,
+                "test:source_one",
+                "test1:target_one",
+                False,
+                True,
+            ),
+        )
+
+        # User can invite external user to a non-published room
+        self.assertTrue(
+            await self._test_user_may_invite(
+                config,
+                "test:source_one",
+                "test:target_two",
+                False,
+                False,
+            ),
+        )
+
     async def test_disallowed(self) -> None:
         config = {
             "can_invite_if_not_in_domain_mapping": True,
             "domain_mapping": {
                 "source_one": ["target_one", "target_two"],
                 "source_two": ["target_two"],
+                "source_four": [],
+            },
+            "domains_prevented_from_being_invited_to_published_rooms": ["target_two"],
+        }
+
+        # Check that a user can't invite a remote server if the domain mapping doesn't
+        # allow it.
+        self.assertFalse(
+            await self._test_user_may_invite(
+                config,
+                "test:source_one",
+                "test:target_three",
+                False,
+                False,
+            )
+        )
+
+        # Check that a user can't invite a remote server if the domain mapping doesn't
+        # allow it.
+        self.assertFalse(
+            await self._test_user_may_invite(
+                config,
+                "test:source_two",
+                "test:target_three",
+                False,
+                False,
+            )
+        )
+
+        # Check that a user can't invite a remote server if the domain mapping doesn't
+        # allow it.
+        self.assertFalse(
+            await self._test_user_may_invite(
+                config, "test:source_two", "test:target_one", False, False
+            )
+        )
+
+        # Check that a user can't invite a remote server if the domain mapping doesn't
+        # allow it.
+        self.assertFalse(
+            await self._test_user_may_invite(
+                config, "test:source_four", "test:target_one", False, False
+            )
+        )
+
+        # User cannot invite external user to a published room
+        self.assertFalse(
+            await self._test_user_may_invite(
+                config, "test:source_one", "test:target_two", False, True
+            )
+        )
+
+    async def test_disallowed_regex(self) -> None:
+        config = {
+            "can_invite_if_not_in_domain_mapping": True,
+            "use_regex": True,
+            "domain_mapping": {
+                "source_(one|two)": ["target_two"],
                 "source_four": [],
             },
             "domains_prevented_from_being_invited_to_published_rooms": ["target_two"],
@@ -181,6 +305,17 @@ class DomainRuleCheckerTestCase(aiounittest.AsyncTestCase):
             },
         }
 
+        self.assertTrue(
+            await self._test_user_may_invite(
+                config,
+                "test:source_three",
+                "test:target_one",
+                False,
+                False,
+            )
+        )
+
+        config["use_regex"] = True
         self.assertTrue(
             await self._test_user_may_invite(
                 config,


### PR DESCRIPTION
- Provides ability to match domains with regex instead of full match
- Some minor improvements (Using Set instead of List where it makes sense)
- Getting rid of test for python 3.7, as that version isn't supported by Synapse anymore, and it was making type hints more complicated